### PR TITLE
chore(arm): Add aarch64 as arm64 architecture

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -32,7 +32,7 @@ get_arch() {
     amd64 | x86_64)
       echo "-amd64"
       ;;
-    arm64)
+    arm64 | aarch64)
       echo "-arm64"
       ;;
     *)


### PR DESCRIPTION
Hello,
I tried to install the plugin in an alpine container on a Mac with an arm processor.
In the container, the command `uname -m` returns aarch64, not arm64.
With this change, the URL is ok.